### PR TITLE
fix: handle border edge cases in median_filter and Gaussian_blur functions

### DIFF
--- a/visionflow/preprocess.py
+++ b/visionflow/preprocess.py
@@ -44,12 +44,12 @@ def normalize_img(img):
 def median_filter(img, ksize=3):
     pad = ksize // 2
     #Only takes rgb images
-    #border edge cases are not handled
+    
     padded_img = np.pad(img, [(pad, pad), (pad, pad), (0, 0)], mode='reflect')
     out = np.zeros_like(img, dtype=np.float32)
     for i in range(img.shape[0]):
         for j in range(img.shape[1]):
-            region = img[i:i+ksize, j:j+ksize]
+            region = padded_img[i:i+ksize, j:j+ksize]
             for c in range(img.shape[2]):
                  out[i, j, c] = np.median(region[:,:,c])
     return out.astype(img.dtype)
@@ -64,14 +64,14 @@ def Gaussian_kernel(ksize, sigma):
 #
 def Gaussian_blur(img, sigma, ksize = 3):
     #Only takes rgb images
-    #border edge cases are not handled
+    
     kernel = Gaussian_kernel(ksize, sigma)
     pad = ksize // 2
     padded_img = np.pad(img, [(pad, pad), (pad, pad), (0, 0)], mode='reflect')
     out = np.zeros_like(img, dtype=np.float32)
     for i in range(img.shape[0]):
         for j in range(img.shape[1]):
-            region = img[i:i+ksize, j:j+ksize]
+            region = padded_img[i:i+ksize, j:j+ksize]
             out[i, j] = np.sum(region * kernel[:, :, np.newaxis], axis=(0,1))
     return out.astype(img.dtype)
 


### PR DESCRIPTION
This pull request updates the image preprocessing functions in `visionflow/preprocess.py` to correctly handle border edge cases by using the padded image when extracting regions for filtering. This ensures that median and Gaussian blur filters work as expected at the edges of images.
Fixes #2 